### PR TITLE
Add Desktop Responsive

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -375,29 +375,6 @@ input::-webkit-inner-spin-button {
     font-size: 22px;
   }
 
-  /* Media Query: hero-poster desktop responsive  */
-  @media (min-width: 1024px) {
-    .hero-poster {
-        grid-auto-flow: row; 
-        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); 
-        overflow-x: visible; 
-    }
-
-    .hero-poster > img {
-        width: 320px; 
-        height: 240px; 
-        padding: 30px; 
-  }
-  
-    .hero-title > p {
-        font-size: 24px; 
-  }
-  
-    .hero-title > p:nth-child(2) {
-        font-size: 26px; 
-  }
-  }
-
   .section-info{
     width: 100%;
   }
@@ -511,25 +488,6 @@ input::-webkit-inner-spin-button {
     font-size: 10px;
     text-transform: uppercase;
     background-color: var(--main-clr)
-  }
-
-  /* Media Query: resources cards Desktop Responsive */
-  @media (min-width: 1024px) {
-    .resources-card {
-        grid-auto-flow: row; 
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); 
-        overflow-x: visible; 
-    }
-
-    .resources-card > .card-holder {
-        width: 230px; 
-        height: 240px; 
-        padding: 30px; 
-    }
-
-    .resources-card > .card-holder > .card-poster > img:hover {
-        transform: scale(1.1); 
-    }
   }
 
   .start-your-subscription{

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -387,15 +387,15 @@ input::-webkit-inner-spin-button {
         width: 320px; 
         height: 240px; 
         padding: 30px; 
-    }
-
+  }
+  
     .hero-title > p {
         font-size: 24px; 
-    }
-
+  }
+  
     .hero-title > p:nth-child(2) {
         font-size: 26px; 
-    }
+  }
   }
 
   .section-info{
@@ -755,76 +755,146 @@ th,td{
   text-transform: capitalize;
 }
 
-th{
-  display: none;
-}
-table,tbody{
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border: 0.5px solid #00000046;
-}
+@media (max-width: 650px) {
+  th{
+    display: none;
+  }
+  table,tbody{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 0.5px solid #00000046;
+  }
 
-.price{
-  font-weight: bolder;
-  font-size: 25px;
-}
+  .price{
+    font-weight: bolder;
+    font-size: 25px;
+  }
 
-td{
-  display: block;
-  padding: 0.5rem 1rem;
-  margin-bottom: 5px;
-  text-align: center;
-}
+  td{
+    display: block;
+    padding: 0.5rem 1rem;
+    margin-bottom: 5px;
+    text-align: center;
+  }
 
-.Annually{
-  background-color: var(--s-clr);
-  color: var(--p-clr);
-}
+  .Annually{
+    background-color: var(--s-clr);
+    color: var(--p-clr);
+  }
 
-td::before{
-  content: attr(data-cell) " ";
-  font-weight: lighter;
-  text-transform: capitalize;
+  td::before{
+    content: attr(data-cell) " ";
+    font-weight: lighter;
+    text-transform: capitalize;
 
-}
+  }
 
-.monthly::before{
-  content: "Monthly Plan";
-  width: 180px;
-  height: 50px;
-  position: absolute;
-  transform: translate(10px,-50px);
-  border-top-left-radius: 5px;
-  border-top-right-radius: 5px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: var(--s-clr);
-  font-size: 1rem;
-  font-weight: lighter;
-  text-transform: capitalize;
-    
-}
+  .monthly::before{
+    content: "Monthly Plan";
+    width: 180px;
+    height: 50px;
+    position: absolute;
+    transform: translate(10px,-50px);
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--s-clr);
+    font-size: 1rem;
+    font-weight: lighter;
+    text-transform: capitalize;
+      
+  }
 
-.Annually::before{
-  content: "Yearly Plan";
-  width: 180px;
-  height: 50px;
-  position: absolute;
-  transform: translate(10px,-50px);
-  border-top-left-radius: 5px;
-  border-top-right-radius: 5px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: var(--s-clr);
-  font-size: 1rem;
-  font-weight: lighter;
-  text-transform: capitalize;
+  .Annually::before{
+    content: "Yearly Plan";
+    width: 180px;
+    height: 50px;
+    position: absolute;
+    transform: translate(10px,-50px);
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--s-clr);
+    font-size: 1rem;
+    font-weight: lighter;
+    text-transform: capitalize;
+  }
 }
 
 @media (min-width: 768px) {
+  th{
+    display: none;
+  }
+  table,tbody{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 0.5px solid #00000046;
+  }
+  
+  .price{
+    font-weight: bolder;
+    font-size: 25px;
+  }
+  
+  td{
+    display: block;
+    padding: 0.5rem 1rem;
+    margin-bottom: 5px;
+    text-align: center;
+  }
+  
+  .Annually{
+    background-color: var(--s-clr);
+    color: var(--p-clr);
+  }
+  
+  td::before{
+    content: attr(data-cell) " ";
+    font-weight: lighter;
+    text-transform: capitalize;
+  
+  }
+  
+  .monthly::before{
+    content: "Monthly Plan";
+    width: 180px;
+    height: 50px;
+    position: absolute;
+    transform: translate(10px,-50px);
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--s-clr);
+    font-size: 1rem;
+    font-weight: lighter;
+    text-transform: capitalize;
+      
+  }
+  
+  .Annually::before{
+    content: "Yearly Plan";
+    width: 180px;
+    height: 50px;
+    position: absolute;
+    transform: translate(10px,-50px);
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--s-clr);
+    font-size: 1rem;
+    font-weight: lighter;
+    text-transform: capitalize;
+  }
   .monthly::before, .Annually::before {
       font-size: 1.5rem; 
   }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -153,6 +153,22 @@ input::-webkit-inner-spin-button {
 
   }
 
+  /* Nav-bar desktop responsive */
+  @media (min-width: 1024px) {
+    .nav-bar {
+        padding: 15px 30px; 
+    }
+
+    .nav-btn {
+        margin-right: 2rem; 
+    }
+
+    .custom-link {
+        margin: 6px; 
+        gap: 3px;   
+    }
+  }
+
   /* Register and login Page */
 
   .heroImage{
@@ -359,6 +375,29 @@ input::-webkit-inner-spin-button {
     font-size: 22px;
   }
 
+  /* Media Query: hero-poster desktop responsive  */
+  @media (min-width: 1024px) {
+    .hero-poster {
+        grid-auto-flow: row; 
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); 
+        overflow-x: visible; 
+    }
+
+    .hero-poster > img {
+        width: 320px; 
+        height: 240px; 
+        padding: 30px; 
+    }
+
+    .hero-title > p {
+        font-size: 24px; 
+    }
+
+    .hero-title > p:nth-child(2) {
+        font-size: 26px; 
+    }
+  }
+
   .section-info{
     width: 100%;
   }
@@ -472,6 +511,25 @@ input::-webkit-inner-spin-button {
     font-size: 10px;
     text-transform: uppercase;
     background-color: var(--main-clr)
+  }
+
+  /* Media Query: resources cards Desktop Responsive */
+  @media (min-width: 1024px) {
+    .resources-card {
+        grid-auto-flow: row; 
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); 
+        overflow-x: visible; 
+    }
+
+    .resources-card > .card-holder {
+        width: 230px; 
+        height: 240px; 
+        padding: 30px; 
+    }
+
+    .resources-card > .card-holder > .card-poster > img:hover {
+        transform: scale(1.1); 
+    }
   }
 
   .start-your-subscription{
@@ -697,75 +755,86 @@ th,td{
   text-transform: capitalize;
 }
 
-@media (max-width: 650px) {
-  th{
-    display: none;
-  }
-  table,tbody{
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border: 0.5px solid #00000046;
-  }
+th{
+  display: none;
+}
+table,tbody{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 0.5px solid #00000046;
+}
 
-  .price{
-    font-weight: bolder;
-    font-size: 25px;
-  }
+.price{
+  font-weight: bolder;
+  font-size: 25px;
+}
 
-  td{
-    display: block;
-    padding: 0.5rem 1rem;
-    margin-bottom: 5px;
-    text-align: center;
-  }
+td{
+  display: block;
+  padding: 0.5rem 1rem;
+  margin-bottom: 5px;
+  text-align: center;
+}
 
-  .Annually{
-    background-color: var(--s-clr);
-    color: var(--p-clr);
-  }
+.Annually{
+  background-color: var(--s-clr);
+  color: var(--p-clr);
+}
 
-  td::before{
-    content: attr(data-cell) " ";
-    font-weight: lighter;
-    text-transform: capitalize;
+td::before{
+  content: attr(data-cell) " ";
+  font-weight: lighter;
+  text-transform: capitalize;
 
-  }
+}
 
-  .monthly::before{
-    content: "Monthly Plan";
-    width: 180px;
-    height: 50px;
-    position: absolute;
-    transform: translate(10px,-50px);
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: var(--s-clr);
-    font-size: 1rem;
-    font-weight: lighter;
-    text-transform: capitalize;
+.monthly::before{
+  content: "Monthly Plan";
+  width: 180px;
+  height: 50px;
+  position: absolute;
+  transform: translate(10px,-50px);
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--s-clr);
+  font-size: 1rem;
+  font-weight: lighter;
+  text-transform: capitalize;
     
-  }
+}
 
-  .Annually::before{
-    content: "Yearly Plan";
-    width: 180px;
-    height: 50px;
-    position: absolute;
-    transform: translate(10px,-50px);
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: var(--s-clr);
-    font-size: 1rem;
-    font-weight: lighter;
-    text-transform: capitalize;
-    
+.Annually::before{
+  content: "Yearly Plan";
+  width: 180px;
+  height: 50px;
+  position: absolute;
+  transform: translate(10px,-50px);
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--s-clr);
+  font-size: 1rem;
+  font-weight: lighter;
+  text-transform: capitalize;
+}
+
+@media (min-width: 768px) {
+  .monthly::before, .Annually::before {
+      font-size: 1.5rem; 
+  }
+  th, td {
+      border-top: none; 
+      border-bottom: none;
+  }
+  table, tbody {
+      border-top: none; 
+      border-bottom: none;
   }
 }
 


### PR DESCRIPTION
Fixes #8
Adjusted the CSS styles to ensure the elements align properly on the desktop view. Added media queries to cater to desktop screen sizes.
Screenshots:
Before: 
The price table is messy.
<img width="576" alt="B1" src="https://github.com/ZiaCodes/Yogavar/assets/122199576/6a8d8407-31de-49e8-882a-a90344f725c0">

Cannot swipe through the row of pictures on the computer like on a phone.
<img width="960" alt="B2" src="https://github.com/ZiaCodes/Yogavar/assets/122199576/374c1527-08e3-40a9-b61a-0c7cd88231f7">
<img width="960" alt="B3" src="https://github.com/ZiaCodes/Yogavar/assets/122199576/5d89cac1-5f19-4148-a988-cb6fecbdc115">

Now:

Add media queries to display all cards：

<img width="960" alt="N1" src="https://github.com/ZiaCodes/Yogavar/assets/122199576/aa9ca263-85b1-4789-9064-5cb6d679805b">
<img width="960" alt="N2" src="https://github.com/ZiaCodes/Yogavar/assets/122199576/c660872e-30f6-46af-8b84-28aad0db763a">

The price table displayed on desktop is now as tidy and aesthetically pleasing as it is on mobile.
<img width="960" alt="N3" src="https://github.com/ZiaCodes/Yogavar/assets/122199576/97083117-05ba-4f52-9ceb-d17f262926dc">

